### PR TITLE
add Node Security Platform (NSP) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - npm install fh-build -g
   - npm install nsp -g
   - fh-build template
-scripts:
+script:
   - npm run-script grunt-eslint
   - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ node_js:
   - '4.4'
 before_install:
   - npm install fh-build -g
+  - npm install nsp -g
   - fh-build template
 scripts:
   - npm run-script grunt-eslint
+  - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 install: npm install
 notifications:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -151,9 +151,9 @@
               }
             },
             "negotiator": {
-              "version": "0.5.3",
-              "from": "negotiator@0.5.3",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+              "version": "0.6.1",
+              "from": "negotiator@0.6.1",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
@@ -286,9 +286,9 @@
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         },
         "send": {
-          "version": "0.13.1",
-          "from": "send@0.13.1",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "version": "0.14.1",
+          "from": "send@0.14.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
@@ -330,9 +330,9 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
           "dependencies": {
             "send": {
-              "version": "0.13.2",
-              "from": "send@0.13.2",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+              "version": "0.14.1",
+              "from": "send@0.14.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
@@ -925,9 +925,9 @@
                       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
                     },
                     "moment": {
-                      "version": "2.13.0",
-                      "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+                      "version": "2.15.1",
+                      "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
                     }
                   }
                 },
@@ -1380,9 +1380,9 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.7",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "rc": {
                   "version": "0.1.1",
@@ -1606,9 +1606,9 @@
           }
         },
         "moment": {
-          "version": "2.14.1",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
+          "version": "2.15.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
         },
         "mongodb-uri": {
           "version": "0.9.7",
@@ -2388,9 +2388,9 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.2",
@@ -3139,9 +3139,9 @@
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.2",
@@ -3251,9 +3251,9 @@
                           }
                         },
                         "negotiator": {
-                          "version": "0.4.9",
-                          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
-                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                          "version": "0.6.1",
+                          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                         }
                       }
                     },
@@ -3263,9 +3263,9 @@
                       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
                     },
                     "cookie-signature": {
-                      "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                     },
                     "debug": {
                       "version": "2.1.3",
@@ -3273,9 +3273,9 @@
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                       "dependencies": {
                         "ms": {
-                          "version": "0.7.0",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
@@ -3371,9 +3371,9 @@
                       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
                     },
                     "send": {
-                      "version": "0.10.1",
-                      "from": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
+                      "version": "0.14.1",
+                      "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                       "dependencies": {
                         "destroy": {
                           "version": "1.0.3",
@@ -3381,9 +3381,9 @@
                           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                         },
                         "ms": {
-                          "version": "0.6.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                          "version": "0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         },
                         "on-finished": {
                           "version": "2.1.1",
@@ -3473,9 +3473,9 @@
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                     },
                     "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                      "version": "1.4.7",
+                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
                     "rc": {
                       "version": "0.1.1",
@@ -3638,14 +3638,14 @@
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                      "version": "1.4.7",
+                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.1",
@@ -3680,9 +3680,9 @@
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                     },
                     "hawk": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "version": "3.1.3",
+                      "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
@@ -3765,9 +3765,9 @@
               "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz"
             },
             "moment": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz"
+              "version": "2.15.1",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
             },
             "mongodb-uri": {
               "version": "0.9.7",
@@ -4202,9 +4202,9 @@
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.2.1",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.2",
@@ -4653,9 +4653,9 @@
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.2",
-          "from": "tough-cookie@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+          "version": "2.3.1",
+          "from": "tough-cookie@2.3.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.3",


### PR DESCRIPTION
Motivation:
To help identify/discover known vulnerabilities in this project.

Modifications:
Added nsp to the CI configuration (Travis).

Result:
nsp check will be run as part of CI

JIRA:
https://issues.jboss.org/browse/RAINCATCH-208
