### PR TITLE
Allow auth response exclusion fields to be specified externally

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,11 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
   },
+  "parserOptions": {
+     "ecmaVersion": 6
+    },
   "extends": "eslint:recommended",
   "rules": {
     "array-callback-return": "warn",
@@ -26,7 +30,8 @@
     "curly": ["error", "all"]
   },
   "globals": {
-    "angular": false
+    "angular": false,
+    "$fh": false,
+    "localStorage": false
   }
 }
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
   - npm install grunt-cli -g
 script:
   - npm run-script grunt-eslint
-  - nsp check
-  - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+  - nsp check; exit 0
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 install: npm install
 notifications:
   email: false
@@ -24,4 +24,3 @@ notifications:
       secure: >-
         KM083myZVOsE8cCoP4bJWLoG/HZkmYqK57o4n3DSHtq500q9/j/BJ2v7aL/AJhjk2IPm1dKKg0NPUO1zEHgKbmjg2xv/uektzbSuoTnyz9QMBq2MOj3n3BjOvn4yRpz2cTVBZHrwFeNzinKIx1L+WPCGBPb5hjeVohtwwZc0eMDirmsyrvPV29Tqjj0wSABds5+zm8OmZvGeQ78UES7ChgS4NtoRISoBPrwEKxhd8vjgnkaaCztVx/loIHYJyAilQDotk4Es3hnfMmHGfOSYwFuduDqNnq3kK4tvYs77UT1crQ0wo+D0shdtMLv334FfiCmTDBHNoukUFKjtK160uSIsVkYNOLB5RqxaxWq8RR/BkuKS/ACLByT7BJyjizg4TrJC6OUxTcHdFJstjI7Cos7r5Q/+JqYZPQ8t3THiYrk8NMhmPQRAC8PyNJwg3bZvGieYYPNCaYKUrdFOdko05NtQEb+WXjYmC2vY/Q0Urej8rjEApZA3sdCJDDHLzNo/GAFTzhaViaWai8WgAbFe6G+Lo6UxQAx9nWLBsVmeGT5t2NqNly7/RSerJHPlWyWfufAKP3tPNig6sBChQW/zfQ3I4GKyuyvKgb4TL5oJgEo/rPuczU/irSTDT/xsSrgHZEqp4+NFIsWtrks3kaAbWvUYqHTp0guXCTY+WmNtE0Y=
     on_pull_requests: false
-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@
 
 module.exports = function(grunt) {
   require('time-grunt')(grunt);
+  grunt.loadNpmTasks('grunt-mocha-test');
   // Project Configuration
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -70,19 +71,20 @@ module.exports = function(grunt) {
     'node-inspector': {
       dev: {}
     },
+    mochaTest: {
+      test: {
+        options: {
+          run: true
+        },
+        src: ['test/unit/*.js']
+      }
+    },
     shell: {
       debug: {
         options: {
           stdout: true
         },
         command: 'env NODE_PATH=. node --debug-brk application.js'
-      },
-      unit: {
-        options: {
-          stdout: true,
-          stderr: true
-        },
-        command: 'env NODE_PATH=. ./node_modules/.bin/mocha -A -u exports --recursive test/unit/'
       },
       accept: {
         options: {
@@ -149,7 +151,7 @@ module.exports = function(grunt) {
 
   // Testing tasks
   grunt.registerTask('test', ['eslint', 'shell:unit', 'shell:accept']);
-  grunt.registerTask('unit', ['eslint', 'shell:unit']);
+  grunt.registerTask('unit', ['eslint','mochaTest']);
   grunt.registerTask('accept', ['env:local', 'shell:accept']);
 
   // Coverate tasks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An Authentication Service for RainCatcher based projects, can be used as mbaas service inside a Red Hat Mobile PLatform instance but also run in standalone mode for local development.
 
-This repository should be used in conjonction with these following repos :
+This repository should be used in conjunction with these following repos :
 
 - [Portal Demo App](https://github.com/feedhenry-raincatcher/raincatcher-demo-portal)
 - [Mobile Client Demo App](https://github.com/feedhenry-raincatcher/raincatcher-demo-mobile)

--- a/application.js
+++ b/application.js
@@ -4,6 +4,7 @@ var mbaasExpress = mbaasApi.mbaasExpress();
 var cors = require('cors');
 var mediator = require('fh-wfm-mediator/lib/mediator');
 var bodyParser = require('body-parser');
+var raincatcherUser = require('fh-wfm-user/lib/router/mbaas');
 
 // list the endpoints which you want to make securable here
 var securableEndpoints;
@@ -26,7 +27,11 @@ app.use(mbaasExpress.fhmiddleware());
 
 app.use('/hello', require('./lib/hello.js')());
 app.use('/api', bodyParser.json({limit: '10mb'}));
-require('fh-wfm-user/lib/router/mbaas')(mediator, app);
+
+// list the user fields which you don't want appearing in the authentication response.
+// This is being consumed in the raincacther-user mbaas router.
+var authResponseExclusionList = ['password'];
+raincatcherUser.init(mediator, app, authResponseExclusionList);
 
 // app modules
 require('./lib/user')(mediator);

--- a/lib/data.json
+++ b/lib/data.json
@@ -8,7 +8,8 @@
     "email" : "trever@wfm.com",
     "notes" : "Trever doesn't work during the weekends.",
     "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/kolage/128.jpg",
-    "banner" : "http://web18.streamhoster.com/pentonmedia/beefmagazine.com/TreverStockyards_38371.jpg"
+    "banner" : "http://web18.streamhoster.com/pentonmedia/beefmagazine.com/TreverStockyards_38371.jpg",
+    "password": "Pa"
   },
   {
     "id" : "rJeXyfdrH",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-env": "0.4.4",
     "grunt-eslint": "^18.0.0",
+    "grunt-mocha-test": "^0.13.2",
     "grunt-node-inspector": "0.4.1",
     "grunt-nodemon": "0.4.1",
     "grunt-open": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-app",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.1-alpha.1",
   "dependencies": {
     "body-parser": "1.15.0",
     "cors": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "express": "4.14.0",
     "fh-mbaas-api": "6.0.1",
     "fh-wfm-mediator": "0.0.15",
-    "fh-wfm-user": "0.0.25",
+    "fh-wfm-user": "0.0.26-alpha.5",
     "lodash": "4.7.0",
     "request": "2.78.0",
     "shortid": "^2.2.6"

--- a/test/unit/test_application.js
+++ b/test/unit/test_application.js
@@ -65,85 +65,86 @@ var mockCors = function() {
 // require the main app file, with mocked dependencies
 var runApp = function() {
   mockMbaasApi = createMockMbaasApi();
-  proxyquire('application.js', {
+  proxyquire('../../application.js', {
     'express': mockExpressApp,
     'fh-mbaas-api': mockMbaasApi,
     'cors': mockCors
   });
 };
 
-exports['test instantiate the user module with the required parameters'] = function(done) {
-  runApp();
+describe('Test mbass functionality', function() {
 
-  // stub the init function in the mbass router in fh-wfm-user
-  var authInit = sinon.stub(require('fh-wfm-user/lib/router/mbaas'), 'init');
-  authInit.yields();
+  it('test instantiate the user module with the required parameters', function(done) {
+    // stub the init function in the mbass router in fh-wfm-user
+    var authInit = sinon.stub(require('fh-wfm-user/lib/router/mbaas'), 'init');
+    authInit.yields();
 
-  // setup paramaters to send
-  var expectedMediator = {};
-  var expectedApp = {};
-  var expectedAuthResponseExclusionList = ['password'];
+    // setup paramaters to send
+    var expectedMediator = {};
+    var expectedApp = {};
+    var expectedAuthResponseExclusionList = ['password'];
 
-  // setup spy, this will spy on the init method in the mbass router in fh-wfm-user
-  var callback = sinon.spy();
+    // setup spy, this will spy on the init method in the mbass router in fh-wfm-user
+    var callback = sinon.spy();
 
-  // called the init function in the mbass router in fh-wfm-user
-  require('fh-wfm-user/lib/router/mbaas').init(expectedMediator, expectedApp, expectedAuthResponseExclusionList, callback);
+    // called the init function in the mbass router in fh-wfm-user
+    require('fh-wfm-user/lib/router/mbaas').init(expectedMediator, expectedApp, expectedAuthResponseExclusionList, callback);
 
-  authInit.restore();
+    authInit.restore();
 
-  // confrm that the function was called with the correct parameters
-  sinon.assert.calledOnce(callback);
-  sinon.assert.calledWith(authInit, expectedMediator, expectedApp, expectedAuthResponseExclusionList);
+    // confrm that the function was called with the correct parameters
+    sinon.assert.calledOnce(callback);
+    sinon.assert.calledWith(authInit, expectedMediator, expectedApp, expectedAuthResponseExclusionList);
 
-  return done();
-};
+    done();
+  });
 
-exports['test express app listen is called'] = function(done) {
-  var mock = sinon.mock(mockExpress);
-  mock.expects("listen").once().withArgs(8001, '0.0.0.0');
+  it('test express app listen is called', function(done) {
+    var mock = sinon.mock(mockExpress);
+    mock.expects("listen").once().withArgs(8001, '0.0.0.0');
 
-  runApp();
+    runApp();
 
-  mock.verify();
-  return done();
-};
+    mock.verify();
+    done();
+  });
 
-exports['test all mbaas routes are mounted'] = function(done) {
-  var mock = sinon.mock(mockExpress);
-  mock.expects("use").once().withArgs('/sys', mockSysHandler);
-  mock.expects("use").once().withArgs('/mbaas', mockMbaasHandler);
-  mock.expects("use").atLeast(4); // allow for other calls to use()
+  it('test all mbaas routes are mounted', function(done) {
+    var mock = sinon.mock(mockExpress);
+    mock.expects("use").once().withArgs('/sys', mockSysHandler);
+    mock.expects("use").once().withArgs('/mbaas', mockMbaasHandler);
+    mock.expects("use").atLeast(4); // allow for other calls to use()
 
-  runApp();
+    runApp();
 
-  mock.verify();
-  return done();
-};
+    mock.verify();
+    done();
+  });
 
-exports['test all mbaas setup functions are called'] = function(done) {
-  runApp();
+  it('test all mbaas setup functions are called', function(done) {
+    runApp();
 
-  // easier to use assertions here on spies instead of mocks
-  // because of the nesting of functions & handlers in fh-mbaas-api
-  sinon.assert.calledOnce(mockMbaasApi.mbaasExpress);
-  sinon.assert.calledOnce(mockSys);
-  sinon.assert.calledOnce(mockFhMiddleware);
-  sinon.assert.calledOnce(mockError);
+    // easier to use assertions here on spies instead of mocks
+    // because of the nesting of functions & handlers in fh-mbaas-api
+    sinon.assert.calledOnce(mockMbaasApi.mbaasExpress);
+    sinon.assert.calledOnce(mockSys);
+    sinon.assert.calledOnce(mockFhMiddleware);
+    sinon.assert.calledOnce(mockError);
 
-  return done();
-};
+    done();
+  });
 
-exports['test all required middleware is added to express'] = function(done) {
-  var mock = sinon.mock(mockExpress);
-  mock.expects("use").once().withArgs(mockCorsHandler);
-  mock.expects("use").once().withArgs(mockStaticHandler);
-  mock.expects("use").once().withArgs(mockFhMiddlewareHandler);
-  mock.expects("use").once().withArgs(mockErrorHandler);
-  mock.expects("use").atLeast(3); // allow for other calls to use()
+  it('test all required middleware is added to express', function(done) {
+    var mock = sinon.mock(mockExpress);
+    mock.expects("use").once().withArgs(mockCorsHandler);
+    mock.expects("use").once().withArgs(mockStaticHandler);
+    mock.expects("use").once().withArgs(mockFhMiddlewareHandler);
+    mock.expects("use").once().withArgs(mockErrorHandler);
+    mock.expects("use").atLeast(3); // allow for other calls to use()
 
-  runApp();
+    runApp();
 
-  mock.verify();
-  return done();
-};
+    mock.verify();
+    done();
+  });
+});

--- a/test/unit/test_application.js
+++ b/test/unit/test_application.js
@@ -72,6 +72,33 @@ var runApp = function() {
   });
 };
 
+exports['test instantiate the user module with the required parameters'] = function(done) {
+  runApp();
+
+  // stub the init function in the mbass router in fh-wfm-user
+  var authInit = sinon.stub(require('fh-wfm-user/lib/router/mbaas'), 'init');
+  authInit.yields();
+
+  // setup paramaters to send
+  var expectedMediator = {};
+  var expectedApp = {};
+  var expectedAuthResponseExclusionList = ['password'];
+
+  // setup spy, this will spy on the init method in the mbass router in fh-wfm-user
+  var callback = sinon.spy();
+
+  // called the init function in the mbass router in fh-wfm-user
+  require('fh-wfm-user/lib/router/mbaas').init(expectedMediator, expectedApp, expectedAuthResponseExclusionList, callback);
+
+  authInit.restore();
+
+  // confrm that the function was called with the correct parameters
+  sinon.assert.calledOnce(callback);
+  sinon.assert.calledWith(authInit, expectedMediator, expectedApp, expectedAuthResponseExclusionList);
+
+  return done();
+};
+
 exports['test express app listen is called'] = function(done) {
   var mock = sinon.mock(mockExpress);
   mock.expects("listen").once().withArgs(8001, '0.0.0.0');


### PR DESCRIPTION
**Motivation**

Based on [this feedback](https://github.com/feedhenry-raincatcher/raincatcher-user/pull/11#discussion_r90840005), added support to specify the user auth exclusion list outside of raincatcher-user. This config is defined in the same place and manner as the `securableEndpoints` config.