### PR TITLE
[RAINCATCH 488] add data reset endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ This repository should be used in conjunction with these following repos :
 ## Starting (locally)
 
 `grunt`
+
+## Seed data
+
+This demo project is seeded with sample user data from [`lib/data.json`](./lib/data.json) upon initialization, make sure to replace this with your own data.
+
+By default all example users' passwords is `'123'`.
+
+# Data reset endpoint
+This service exposes an additional endpoint that is intended for tests and demonstrations at `DELETE /admin/reset`, which causes the underlying data store to be reseeded with the original data for users.
+
+Make sure to deactivate this endpoint when building your own solution on top of this demo, by editing [this file](./lib/routes/admin/index.js).

--- a/application.js
+++ b/application.js
@@ -6,6 +6,7 @@ var mediator = require('fh-wfm-mediator/lib/mediator');
 var bodyParser = require('body-parser');
 var raincatcherUser = require('fh-wfm-user/lib/router/mbaas');
 var sessionInit = require('./lib/sessionInit');
+var adminRouter = require('./lib/routes/admin');
 
 // list the endpoints which you want to make securable here
 var securableEndpoints;
@@ -26,6 +27,8 @@ app.use(express.static(__dirname + '/public'));
 app.use(mbaasExpress.fhmiddleware());
 
 app.use('/api', bodyParser.json({limit: '10mb'}));
+
+app.use('/admin', adminRouter(mediator));
 
 /**
  * Session and Cookie configuration

--- a/lib/routes/admin/index.js
+++ b/lib/routes/admin/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 module.exports = function(mediator) {
   const router = express.Router();
 
+  // TODO: Remove this endpoint when not needed
   if (process.env.NODE_ENV === 'development') {
     /**
      * Asks for data to be reset to the default list of users

--- a/lib/routes/admin/index.js
+++ b/lib/routes/admin/index.js
@@ -10,7 +10,7 @@ module.exports = function(mediator) {
      * This is intended only for demonstration/debugging purposes
      * and by default only runs on NODE_ENV === 'development'
      */
-    router.route('data').delete(function(req, res) {
+    router.route('/data').delete(function(req, res) {
       mediator.request('wfm:data:reset').then(function() {
         res.send('ok');
       }).catch(function(err) {

--- a/lib/routes/admin/index.js
+++ b/lib/routes/admin/index.js
@@ -1,0 +1,22 @@
+const express = require('express');
+
+module.exports = function(mediator) {
+  const router = express.Router();
+
+  if (process.env.NODE_ENV === 'development') {
+    /**
+     * Asks for data to be reset to the default list of users
+     * This is intended only for demonstration/debugging purposes
+     * and by default only runs on NODE_ENV === 'development'
+     */
+    router.route('data').delete(function(req, res) {
+      mediator.request('wfm:data:reset').then(function() {
+        res.send('ok');
+      }).catch(function(err) {
+        res.status(500).send(err);
+      });
+    });
+  }
+
+  return router;
+};

--- a/lib/user-spec.js
+++ b/lib/user-spec.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 const mediator = require('fh-wfm-mediator/lib/mediator');
+const data = require('./data');
+
+const daisyId = 'rJeXyfdrH';
 
 describe('user topics', function() {
   before(function() {
@@ -13,6 +16,20 @@ describe('user topics', function() {
       }, {uid: 'trever'})
       .then(function(match) {
         assert(match, 'password shouldve been valid');
+      });
+    });
+  });
+  describe('reset', function() {
+    it('should reset users to original list', function() {
+      return mediator.request('wfm:user:delete', daisyId)
+      .then(function() {
+        return mediator.request('wfm:data:reset');
+      })
+      .then(function() {
+        return mediator.request('wfm:user:list');
+      })
+      .then(function(users) {
+        return assert.deepEqual(users, data);
       });
     });
   });

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var UserStore = require('fh-wfm-user/lib/user/store');
+var Topics = require('fh-wfm-mediator/lib/topics');
 // Seed data for users, replace with your own.
 var data = require('./data.json');
 
@@ -11,6 +12,14 @@ var data = require('./data.json');
 module.exports = function(mediator) {
   var store = new UserStore('user');
   return store.init(data).then(function() {
-    return store.listen('', mediator);
+    store.listen('', mediator);
+
+    var dataTopics = new Topics(mediator);
+    dataTopics.prefix('wfm').entity('data')
+    .on('reset', function() {
+      return store.deleteAll().then(function() {
+        return store.init(data);
+      });
+    });
   });
 };

--- a/lib/user.js
+++ b/lib/user.js
@@ -2,7 +2,8 @@
 
 var UserStore = require('fh-wfm-user/lib/user/store');
 var Topics = require('fh-wfm-mediator/lib/topics');
-// Seed data for users, replace with your own.
+// TODO: replace this seed data for users with your own
+// i.e. a single initial user to create others through the portal app
 var data = require('./data.json');
 
 /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1842,7 +1842,7 @@
             "node-uuid": {
               "version": "1.4.7",
               "from": "node-uuid@~1.4.7",
-              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.2",
@@ -2296,10 +2296,27 @@
       "from": "fh-wfm-mediator@0.1.0-rc2",
       "resolved": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.1.0-rc2.tgz"
     },
+    "fh-wfm-simple-store": {
+      "version": "0.0.4",
+      "from": "fh-wfm-simple-store@0.0.4",
+      "resolved": "https://registry.npmjs.org/fh-wfm-simple-store/-/fh-wfm-simple-store-0.0.4.tgz",
+      "dependencies": {
+        "fh-wfm-mediator": {
+          "version": "0.1.0-rc1",
+          "from": "fh-wfm-mediator@0.1.0-rc1",
+          "resolved": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.1.0-rc1.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.17.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        }
+      }
+    },
     "fh-wfm-user": {
-      "version": "0.2.0-alpha.8",
-      "from": "fh-wfm-user@>=0.2.0-alpha.8 <0.3.0",
-      "resolved": "https://registry.npmjs.org/fh-wfm-user/-/fh-wfm-user-0.2.0-alpha.8.tgz",
+      "version": "0.3.0-alpha.1",
+      "from": "fh-wfm-user@>=0.3.0-alpha.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/fh-wfm-user/-/fh-wfm-user-0.3.0-alpha.1.tgz",
       "dependencies": {
         "fh-mbaas-api": {
           "version": "5.14.2",
@@ -4340,9 +4357,9 @@
           }
         },
         "fh-wfm-mediator": {
-          "version": "0.0.15",
-          "from": "fh-wfm-mediator@0.0.15",
-          "resolved": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.0.15.tgz"
+          "version": "0.1.0-rc1",
+          "from": "fh-wfm-mediator@0.1.0-rc1",
+          "resolved": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.1.0-rc1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "express": "4.14.0",
     "fh-mbaas-api": "6.1.3",
     "fh-wfm-mediator": "0.1.0-rc2",
-    "fh-wfm-user": "^0.2.0-alpha.8",
+    "fh-wfm-user": "^0.3.0-alpha.1",
     "lodash": "4.7.0",
     "request": "2.78.0",
     "shortid": "^2.2.6"
   },
   "devDependencies": {
+    "cross-env": "^3.1.4",
     "grunt": "0.4.5",
     "grunt-concurrent": "2.2.1",
     "grunt-contrib-jshint": "1.0.0",
@@ -34,7 +35,7 @@
   },
   "main": "application.js",
   "scripts": {
-    "test": "grunt unit",
+    "test": "cross-env WFM_USE_MEMORY_STORE=true grunt unit",
     "debug": "grunt debug",
     "start": "grunt",
     "eslint": "grunt eslint"


### PR DESCRIPTION
# Motivation
Add endpoint for resetting the user collection to initial data

# Changes
- Add endpoint to service (needs update to cloud app to forward request)
- unit test for store
- Bump fh-wfm-user to 0.3.x pre-release (feature/persistent-storage branch)