### PR TITLE
Rhmap 15285 fix login timing build

### DIFF
--- a/application.js
+++ b/application.js
@@ -7,6 +7,7 @@ var bodyParser = require('body-parser');
 var raincatcherUser = require('fh-wfm-user/lib/mbaas');
 var sessionInit = require('./lib/sessionInit');
 var adminRouter = require('./lib/routes/admin');
+var genuuid = require('uid-safe');
 
 // list the endpoints which you want to make securable here
 var securableEndpoints;
@@ -44,6 +45,11 @@ var sessionOptions = {
     secret: process.env.FH_COOKIE_SECRET || 'raincatcher',
     resave: false,
     saveUninitialized: true,
+    genid: function() {
+      //Generating a 24 character session token as required by $fh.auth
+      // (uid-save takes byteLength instead of character length)
+      return genuuid.sync(18);
+    },
     cookie: {
       secure: process.env.NODE_ENV === 'production',
       httpOnly: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-demo-auth",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "dependencies": {
     "bluebird": "3.4.7",
     "body-parser": "1.17.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "express": "4.15.2",
     "fh-mbaas-api": "~7.0.1",
     "fh-wfm-mediator": "0.3.4",
-    "fh-wfm-user": "0.6.2",
+    "fh-wfm-user": "0.6.4-pre.1",
     "lodash": "4.17.4",
     "request": "2.78.0",
     "shortid": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "fh-wfm-user": "0.6.2",
     "lodash": "4.17.4",
     "request": "2.78.0",
-    "shortid": "^2.2.6"
+    "shortid": "2.2.6",
+    "uid-safe": "2.1.4"
   },
   "devDependencies": {
     "cross-env": "^3.1.4",


### PR DESCRIPTION
# Motivation

The $fh.auth API requires a 24 character session when verifying.

Therefore, the session middleware should be passed the genid parameter from the application

Related to https://github.com/feedhenry-raincatcher/raincatcher-user/pull/70

