### PR TITLE
Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,15 @@ services:
   - mongodb
   - docker
 node_js:
-  - '0.10'
-  - '4.4'
+  - '4.4.3'
+  - '6.9.1'
 before_install:
   - npm install grunt-cli -g
 script:
   - npm test
-  - >-
-    bash <(curl
-    https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
-install: npm install
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+install:
+  - npm install
 notifications:
   email: false
   slack:

--- a/Grunt-ReadMe.md
+++ b/Grunt-ReadMe.md
@@ -19,20 +19,6 @@ Note that 'grunt serve' supports live reload, i.e. it will monitor for any chang
 
 Run ```grunt debug``` to debug this App locally. This task uses [Node Inspector](https://github.com/node-inspector/node-inspector) to debug your application, and will open the Debugger at 'application.js' in Google Chrome. See the documentation for [Node Inspector](https://github.com/node-inspector/node-inspector) for more information on how to use Node Inspector.
 
-## grunt test
-
-Run ```grunt test``` to run the unit tests for this App.
-
-## grunt coverage
-
-This App uses [Istanbul](https://github.com/gotwarlost/istanbul) for generating code coverage for your tests.
-
-Run ```grunt coverage``` to run code coverage for this App.
-
-## grunt analysis
-
-Run ```grunt analysis``` to get a static analysis report of your code. This task uses [Plato](https://github.com/es-analysis/plato) to generate the report. See the documentaion for [Plato](https://github.com/es-analysis/plato) for more information on how to use and configure Plato.
-
 ## Environment variables
 
 The [grunt env](https://www.npmjs.org/package/grunt-env) plugin is included by default. To set your own environment variables, modify the `env` config accordingly, e.g.

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "fh-wfm-demo-auth",
   "version": "2.4.0",
   "dependencies": {
-    "bluebird": "3.4.7",
-    "body-parser": "1.17.1",
-    "cors": "2.7.1",
-    "express": "4.15.2",
+    "bluebird": "3.5.0",
+    "body-parser": "1.17.2",
+    "cors": "2.8.3",
+    "express": "4.15.3",
     "fh-mbaas-api": "~7.0.9",
     "fh-wfm-mediator": "0.3.4",
     "fh-wfm-user": "0.6.6",
     "lodash": "4.17.4",
-    "request": "2.78.0",
+    "request": "2.81.0",
     "shortid": "^2.2.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Node 6 support:
- Remove Node 0.10 and add Node 6.9 in travis.yml
- Remove `grunt test`, `grunt coverage`, and `grunt analysis` since they're not implemented
- Update dependencies

JIRA: https://issues.jboss.org/browse/RHMAP-15493